### PR TITLE
remove deprecated update command and use postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "release": "npm version ${BUMP:-\"patch\"} --no-git-tag-version && git add package.json && git commit -m \":octocat: Bump to $(cat package.json | json version)\" && git tag $(cat package.json | json version) && git push && git push --tags && npm publish",
     "test": "mocha",
     "tdd": "mocha -w",
-    "update": "git submodule update --init --recursive && git submodule foreach --recursive git fetch && git submodule foreach git merge origin master"
+    "preinstall": "npm run submodule",
+    "submodule": "git submodule update --init --recursive && git submodule foreach --recursive git fetch && git submodule foreach git merge origin master"
   },
   "files": [
     "generators"


### PR DESCRIPTION
npm has deprecated the update hooks.

sending command `npm update` will only update node_modules but not clone the boilerplate.

a seperate script to clone the boilerplate.

And a hook to `npm install`